### PR TITLE
Allow users with existing WordPress accounts to log in

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -413,8 +413,9 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		}
 
 		// Before trying to create the user, first check if a user with the same email already exists
-		if( $uid = email_exists( $email ) ) {
-			return $this->update_existing_user( $uid, $subject_identity );
+			if( $uid = email_exists( $email ) ) {
+				return $this->update_existing_user( $uid, $subject_identity );
+			}
 		}
 		
 		// allow other plugins / themes to determine authorization 

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -413,6 +413,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		}
 
 		// Before trying to create the user, first check if a user with the same email already exists
+		if( $this->settings->link_existing_users ) {
 			if( $uid = email_exists( $email ) ) {
 				return $this->update_existing_user( $uid, $subject_identity );
 			}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -412,6 +412,11 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			$username = $this->get_username_from_claim( $user_claim );
 		}
 
+		// Before trying to create the user, first check if a user with the same email already exists
+		if( $uid = email_exists( $email ) ) {
+			return $this->update_existing_user( $uid, $subject_identity );
+		}
+		
 		// allow other plugins / themes to determine authorization 
 		// of new accounts based on the returned user claim
 		$create_user = apply_filters( 'openid-connect-generic-user-creation-test', TRUE, $user_claim );
@@ -442,5 +447,26 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		do_action( 'openid-connect-generic-user-create', $user, $user_claim );
 		
 		return $user;
+	}
+	
+	
+	/**
+	 * Update an existing user with OpenID Connect meta data
+	 * 
+	 * @param $uid
+	 * @param $subject_identity
+	 *
+	 * @return \WP_Error | \WP_User
+	 */
+	function update_existing_user( $uid, $subject_identity ) {
+		// add the OpenID Connect meta data 
+		add_user_meta( $uid, 'openid-connect-generic-user', TRUE, TRUE );
+		add_user_meta( $uid, 'openid-connect-generic-subject-identity', (string) $subject_identity, TRUE );
+		
+		// allow plugins / themes to take action on user update
+		do_action( 'openid-connect-generic-user-update', $uid );
+		
+		// return our updated user
+		return get_user_by( 'id', $uid );
 	}
 }

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -111,6 +111,12 @@ class OpenID_Connect_Generic_Settings_Page {
 				'type'        => 'checkbox',
 				'section'     => 'authorization_settings',
 			),
+			'link_existing_users'   => array(
+				'title'       => __( 'Link Existing Users' ),
+				'description' => __( 'If a WordPress account already exists with the same email address as a newly-authenticated user over OpenID Connect, login as that user instead of generating an error.' ),
+				'type'        => 'checkbox',
+				'section'     => 'user_settings',
+			),
 			'enable_logging'    => array(
 				'title'       => __( 'Enable Logging' ),
 				'description' => __( 'Very simple log messages for debugging purposes.' ),
@@ -183,6 +189,12 @@ class OpenID_Connect_Generic_Settings_Page {
 			$this->options_page_name
 		);
 
+		add_settings_section( 'user_settings',
+			__( 'WordPress User Settings' ),
+			array( $this, 'user_settings_description' ),
+			$this->options_page_name
+		);
+		
 		add_settings_section( 'authorization_settings',
 			__( 'Authorization Settings' ),
 			array( $this, 'authorization_settings_description' ),
@@ -356,7 +368,11 @@ class OpenID_Connect_Generic_Settings_Page {
 	public function client_settings_description() {
 		_e( 'Enter your OpenID Connect identity provider settings' );
 	}
-
+	
+	public function user_settings_description() {
+		_e( 'Modify the interaction between OpenID Connect and WordPress users' );
+	}
+	
 	public function authorization_settings_description() {
 		_e( 'Control the authorization mechanics of the site' );
 	}


### PR DESCRIPTION
If a user successfully authenticates for the first time with OpenID Connect but there is already a WordPress account associated with that email address, this plugin fails to log in with "Invalid user" error.

In many scenarios, it would be logical for OpenID Connect to link the successfully authenticated user to the existing WordPress account with the same email address. This patch adds a setting on the settings page to allow this to happen.