### PR TITLE
Add OpenID Connect button shortcode for insertion on any login form

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -263,6 +263,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		// redirect back to the origin page if enabled
 		if( $this->settings->redirect_user_back && !empty( $redirect_url = esc_url( $_COOKIE[ $this->cookie_redirect_key ] ) ) ) {
+			do_action( 'openid-connect-generic-redirect-user-back', $redirect_url, $user );
 			wp_redirect( $redirect_url );
 		}
 		// otherwise, go home!

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -12,7 +12,10 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 	// internal tracking cookie key
 	private $cookie_id_key = 'openid-connect-generic-identity';
-	
+
+	// user redirect cookie key
+	public $cookie_redirect_key = 'openid-connect-generic-redirect';
+
 	// WP_Error if there was a problem, or false if no error
 	private $error = false;
 
@@ -258,8 +261,14 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		// log our success
 		$this->logger->log( "Successful login for: {$user->user_login} ({$user->ID})", 'login-success' );
 
-		// go home!
-		wp_redirect( home_url() );
+		// redirect back to the origin page if enabled
+		if( $this->settings->redirect_user_back && !empty( $redirect_url = esc_url( $_COOKIE[ $this->cookie_redirect_key ] ) ) ) {
+			wp_redirect( $redirect_url );
+		}
+		// otherwise, go home!
+		else {
+			wp_redirect( home_url() );
+		}
 	}
 
 	/**

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -89,10 +89,14 @@ class OpenID_Connect_Generic_Login_Form {
 		// record the URL of this page if set to redirect back to origin page
 		if( $this->settings->redirect_user_back ) {
 			$redirect_expiry = time() + DAY_IN_SECONDS;
-			if ( $GLOBALS['pagenow'] == 'wp-login.php' )
-				$redirect_url = admin_url();
-			else
+			if ( $GLOBALS['pagenow'] == 'wp-login.php' ) {
+				if( isset( $_REQUEST['redirect_to'] ) )
+					$redirect_url = esc_url( $_REQUEST['redirect_to'] );
+				else
+					$redirect_url = admin_url();
+			} else {
 				$redirect_url = home_url( esc_url( add_query_arg( NULL, NULL ) ) );
+			}
 			setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
 		}
 		

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -86,6 +86,16 @@ class OpenID_Connect_Generic_Login_Form {
 		$text = apply_filters( 'openid-connect-generic-login-button-text', __( 'Login with OpenID Connect' ) );
 		$href = $this->client_wrapper->get_authentication_url();
 
+		// record the URL of this page if set to redirect back to origin page
+		if( $this->settings->redirect_user_back ) {
+			$redirect_expiry = time() + DAY_IN_SECONDS;
+			if ( $GLOBALS['pagenow'] == 'wp-login.php' )
+				$redirect_url = admin_url();
+			else
+				$redirect_url = home_url( esc_url( add_query_arg( NULL, NULL ) ) );
+			setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
+		}
+		
 		ob_start();
 		?>
 		<div class="openid-connect-login-button" style="margin: 1em 0; text-align: center;">

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -26,6 +26,9 @@ class OpenID_Connect_Generic_Login_Form {
 		// alter the login form as dictated by settings
 		add_filter( 'login_message', array( $login_form, 'handle_login_page' ), 99 );
 		
+		// add a shortcode for the login button
+		add_shortcode( 'openid_connect_generic_login_button', array( $login_form, 'make_login_button' ) );
+
 		return $login_form;
 	}
 	

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -117,6 +117,12 @@ class OpenID_Connect_Generic_Settings_Page {
 				'type'        => 'checkbox',
 				'section'     => 'user_settings',
 			),
+			'redirect_user_back'   => array(
+				'title'       => __( 'Redirect Back to Origin Page' ),
+				'description' => __( 'After a successful OpenID Connect authentication, this will <strong>override the default action of redirecting the user to the home page and instead redirect the user back to the page on which they clicked the OpenID Connect login button</strong>. This will cause the login process to proceed in a traditional WordPress fashion. For example, users logging in through the default wp-login.php page would end up on the WordPress Dashboard and users logging in through the WooCommerce "My Account" page would end up on their account page.' ),
+				'type'        => 'checkbox',
+				'section'     => 'user_settings',
+			),
 			'enable_logging'    => array(
 				'title'       => __( 'Enable Logging' ),
 				'description' => __( 'Very simple log messages for debugging purposes.' ),

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -3,7 +3,7 @@
 Plugin Name: OpenID Connect - Generic Client
 Plugin URI: https://github.com/daggerhart/openid-connect-generic
 Description:  Connect to an OpenID Connect identity provider with Authorization Code Flow
-Version: 3.0.3
+Version: 3.0.5
 Author: daggerhart
 Author URI: http://www.daggerhart.com
 License: GPLv2 Copyright (c) 2015 daggerhart

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,15 @@ Replace `example.com` with your domain name and path to WordPress.
 ### Changelog
 
 
+**3.0.5**
+
+* Added [openid_connect_generic_login_button] shortcode to allow the login button to be placed anywhere
+* Added setting to "Redirect Back to Origin Page" after a successful login instead of redirecting to the home page.
+
+**3.0.4**
+
+* Added setting to allow linking existing WordPress user accounts with newly-authenticated OpenID Connect login
+
 **3.0.3**
 
 * Using WordPresss's is_ssl() for setcookie()'s "secure" parameter

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,15 @@ Replace `example.com` with your domain name and path to WordPress.
 
 == Changelog ==
 
+= 3.0.5 =
+
+* Added [openid_connect_generic_login_button] shortcode to allow the login button to be placed anywhere
+* Added setting to "Redirect Back to Origin Page" after a successful login instead of redirecting to the home page.
+
+= 3.0.4 =
+
+* Added setting to allow linking existing WordPress user accounts with newly-authenticated OpenID Connect login
+
 = 3.0.3 =
 
 * Using WordPresss's is_ssl() for setcookie()'s "secure" parameter


### PR DESCRIPTION
Adding a simple shortcode for the OpenID Connect login button allows integration with any plugin with a custom login page. For example, the button could be inserted via shortcode into WooCommerce login templates for My Account or Checkout.

Additionally, we can add a setting to allow overriding the plugin default of redirecting to the home page after successful authentication and instead redirect back to the origin page on which the OpenID Connect login button was clicked. This results in the expected WordPress behavior for custom login pages (with WooCommerce, for example, after logging into My Account you are viewing your account or after logging in during Checkout you return to the Checkout page). If the origin page is the default wp-login.php page, the user is sent to wherever the WordPress "redirect_to" parameter specifies, which is usually the WordPress Dashboard.

A case could be made for setting this to be the default redirection behavior of the plugin since it corresponds with the default behavior of WordPress. However, I was concerned that others using this plugin may be confused by this change in default functionality so I left it as an optional setting.