### PR TITLE
Allow users to login with WP account after using OpenID Connect

### DIFF
--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -3,7 +3,7 @@
 Plugin Name: OpenID Connect - Generic Client
 Plugin URI: https://github.com/daggerhart/openid-connect-generic
 Description:  Connect to an OpenID Connect identity provider with Authorization Code Flow
-Version: 3.0.5
+Version: 3.0.6
 Author: daggerhart
 Author URI: http://www.daggerhart.com
 License: GPLv2 Copyright (c) 2015 daggerhart

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,9 @@ Replace `example.com` with your domain name and path to WordPress.
 
 ### Changelog
 
+**3.0.6**
+
+* If "Link Existing Users" is enabled, allow users who login with OpenID Connect to also log in with WordPress credentials
 
 **3.0.5**
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: daggerhart
 Donate link: http://www.daggerhart.com/
 Tags: security, login, oauth2, openidconnect, apps, authentication, autologin, sso 
 Requires at least: 4
-Tested up to: 4.2.2
+Tested up to: 4.5.2
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,10 @@ Replace `example.com` with your domain name and path to WordPress.
 
 
 == Changelog ==
+
+= 3.0.6 =
+
+* If "Link Existing Users" is enabled, allow users who login with OpenID Connect to also log in with WordPress credentials
 
 = 3.0.5 =
 


### PR DESCRIPTION
There is currently a bug where if a user logs in with OpenID Connect they are unable to then log in directly with their WordPress account.  A "Mismatch Identity" error is generated.

The cause of this is the "check_user_token" function in the "openid-connect-generic-client-wrapper.php" function. If a user has "openid-connect-generic-user" flagged in their user meta (meaning that they've successfully connected with OpenID Connect at some point in time), their token is regularly checked to make sure that their OpenID Connect authorization is current.

This functionality might make sense if you wanted to keep OpenID Connect accounts and WordPress accounts completely separate or only allow OpenID Connect authorizations and not WP logins.

However, this is definitely a problem in the case where you have enabled "Link Existing Users" to allow linking successfully authenticated OpenID connections to existing WordPress accounts. As soon as this happens, the user can no longer login through WordPress but is now limited to only using OpenID Connect. 

I thought a lot about this problem and have come up with what I believe is an acceptable solution. If "Link Existing Users" is enabled, the "openid-connect-generic-user" flag is turned off when a user is logged out and turned on when a user logs in via OpenID Connect. It is not enabled when a user logs in via WordPress.

By the way, this bug is probably what was being referenced in this issue mentioned @topperge: https://github.com/daggerhart/openid-connect-generic/pull/1