### PR TITLE
Send access token in the Authorization header when requesting user info

### DIFF
--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -148,7 +148,15 @@ class OpenID_Connect_Generic_Client {
 		// allow modifications to the request
 		$request = apply_filters( 'openid-connect-generic-alter-request', array(), 'get-userinfo' );
 
-		// attempt the request
+		// section 5.3.1 of the spec recommends sending the access token using the authorization header
+		// a filter may or may not have already added headers - make sure they exist then add the token
+		if ( !array_key_exists( 'headers', $request ) || !is_array( $request['headers'] ) ) {
+			$request['headers'] = array();
+		}
+
+		$request['headers']['Authorization'] = 'Bearer '.$access_token;
+
+		// attempt the request including the access token in the query string for backwards compatibility
 		$response = wp_remote_get( $this->endpoint_userinfo . '?access_token=' . $access_token, $request );
 
 		if ( is_wp_error( $response ) ){

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,10 @@ Replace `example.com` with your domain name and path to WordPress.
 
 ### Changelog
 
+**3.0.7**
+* When requesting userinfo, send the access token using the Authorization header field as recommended in 
+section 5.3.1 of the specs. 
+
 **3.0.6**
 
 * If "Link Existing Users" is enabled, allow users who login with OpenID Connect to also log in with WordPress credentials

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,11 @@ Replace `example.com` with your domain name and path to WordPress.
 
 == Changelog ==
 
+= 3.0.7 =
+
+* When requesting userinfo, send the access token using the Authorization header field as recommended in
+  section 5.3.1 of the specs.
+
 = 3.0.6 =
 
 * If "Link Existing Users" is enabled, allow users who login with OpenID Connect to also log in with WordPress credentials


### PR DESCRIPTION
Section 5.3.1 of the specs recommends sending the access token using the Authorization header when requesting user info. Some identity providers seem to only work with the token in the header. This change adds the access token to the Authorization header as recommended, but also includes it as a query string parameter to ensure backwards compatibility with anyone already using it successfully.