### PR TITLE
Added hook for existing user login allowing others to take action using updated claims 

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -253,6 +253,10 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		if ( ! $user ) {
 			$user = $this->create_new_user( $subject_identity, $user_claim );
 		}
+		else {
+			// allow plugins / themes to take action using current claims on existing user (e.g. update role)
+			do_action( 'openid-connect-generic-update-user-using-current-claim', $user, $user_claim );
+		}
 
 		// validate the found / created user
 		$valid = $this->validate_user( $user );

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -22,6 +22,7 @@ Notes
 
   Actions
   - openid-connect-generic-user-create - 2 args: fires when a new user is created by this plugin
+  - openid-connect-generic-update-user-using-current-claim - 2 args: fires every time an existing user logs
 
   User Meta
   - openid-connect-generic-user                - (bool) if the user was created by this plugin

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,9 @@ by this client is like so:  `https://example.com/wp-admin/admin-ajax.php?action=
 Replace `example.com` with your domain name and path to WordPress.
 
 ### Changelog
+**3.0.8**
+* Added [openid-connect-generic-update-user-using-current-claim] action hook allowing other plugins/themes
+  to take action using the fresh claims received when an existing user logs in.
 
 **3.0.7**
 * When requesting userinfo, send the access token using the Authorization header field as recommended in 

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,9 @@ Replace `example.com` with your domain name and path to WordPress.
 
 
 == Changelog ==
+= 3.0.8 =
+* Added [openid-connect-generic-update-user-using-current-claim] action hook allowing other plugins/themes
+  to take action using the fresh claims received when an existing user logs in.
 
 = 3.0.7 =
 


### PR DESCRIPTION
This plugin has some really useful action hooks, including the openid-connect-generic-user-create that fires when a new user is created and includes claims from the identity provider. In the application I’m working on, it was also important to have an action fire when an existing user logs in again, and to include any updated claims. 

I believe there are several uses for this, but in my specific case, we would update the Wordpress role based on the "role" claims we got from the identity provider (IDP Prospect = Wordpress None, IDP Subscriber = Wordpress Subscriber, etc). Since Prospects hopefully turn into Subscribers, roles could change over time, so each time a user logs in we verify the current claims and do any updates.

The changes I’m proposing simply add a new action for this purpose, and shouldn’t cause any issues for current plugin users. Let me know what you think.