### PR TITLE
Fix "redirect to origin" for error redirect

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -303,6 +303,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		// redirect back to the origin page if enabled
 		if( $this->settings->redirect_user_back && !empty( $redirect_url = esc_url( $_COOKIE[ $this->cookie_redirect_key ] ) ) ) {
 			do_action( 'openid-connect-generic-redirect-user-back', $redirect_url, $user );
+			setcookie( $this->cookie_redirect_key, $redirect_url, 1, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
 			wp_redirect( $redirect_url );
 		}
 		// otherwise, go home!

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -41,6 +41,22 @@ class OpenID_Connect_Generic_Login_Form {
 	function handle_login_page( $message ) {
 		$settings = $this->settings;
 
+		// record the URL of this page if set to redirect back to origin page
+		if ( $this->settings->redirect_user_back ) {
+			$redirect_expiry = time() + DAY_IN_SECONDS;
+			if ( $GLOBALS['pagenow'] == 'wp-login.php' ) {
+				if ( isset( $_REQUEST['redirect_to'] ) ) {
+					$redirect_url = esc_url( $_REQUEST[ 'redirect_to' ] );
+				}
+				else {
+					$redirect_url = admin_url();
+				}
+			} else {
+				$redirect_url = home_url( esc_url( add_query_arg( NULL, NULL ) ) );
+			}
+			setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
+		}
+
 		// errors and auto login can't happen at the same time
 		if ( isset( $_GET['login-error'] ) ) {
 			$message = $this->make_error_output( $_GET['login-error'], $_GET['message'] );
@@ -85,20 +101,6 @@ class OpenID_Connect_Generic_Login_Form {
 	function make_login_button() {
 		$text = apply_filters( 'openid-connect-generic-login-button-text', __( 'Login with OpenID Connect' ) );
 		$href = $this->client_wrapper->get_authentication_url();
-
-		// record the URL of this page if set to redirect back to origin page
-		if( $this->settings->redirect_user_back ) {
-			$redirect_expiry = time() + DAY_IN_SECONDS;
-			if ( $GLOBALS['pagenow'] == 'wp-login.php' ) {
-				if( isset( $_REQUEST['redirect_to'] ) )
-					$redirect_url = esc_url( $_REQUEST['redirect_to'] );
-				else
-					$redirect_url = admin_url();
-			} else {
-				$redirect_url = home_url( esc_url( add_query_arg( NULL, NULL ) ) );
-			}
-			setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
-		}
 		
 		ob_start();
 		?>


### PR DESCRIPTION
Hello,
This pull request fixes "redirect to origin" when auto-sso is enabled. At the moment, since the redirect cookie is set in "make_login_button", when auto-sso is enabled, this is skipped and the result is that the origin is lost.

This moves the cookie set to a common path earlier (in login_message) hook so that the cookie is set regardless of the method of login.

In addition, the redirect cookie was not properly cleared (by sending the cookie with same name and parameters but with date in the past) which can cause other issues later. This is also addressed by clearing the cookie during the redirect to the origin.