### PR TITLE
Fix autoloader fail for namespace paths on Linux.

### DIFF
--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -153,6 +153,8 @@ class OpenID_Connect_Generic {
 		$filename = $class . '.php';
 		if ( false === strpos( $class, '\\' ) ) {
 			$filename = strtolower( str_replace( '_', '-', $class ) ) . '.php';
+		} else {
+			$filename = str_replace( '\\', '/', $filename );
 		}
 
 		$filepath = dirname( __FILE__ ) . '/includes/' . $filename;


### PR DESCRIPTION
This fixes a minor bug in #18 where on linux the autoloader failed to load the defuse libraries due to forward slash vs backward slash (windows is more forgiving so it hid the problem), my apologies.