### PR TITLE
OpenID Connect end_session_endpoint integrated logout support

### DIFF
--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -40,7 +40,8 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	function handle_redirect_login_type_auto()
 	{
-		if ( $GLOBALS['pagenow'] == 'wp-login.php' && $this->settings->login_type == 'auto' )
+		if ( $GLOBALS['pagenow'] == 'wp-login.php' && $this->settings->login_type == 'auto'
+			&& ( ! isset( $_GET[ 'action' ] ) || $_GET[ 'action' ] !== 'logout' ) )
 		{
 			if (  ! isset( $_GET['login-error'] ) ) {
 				wp_redirect( $this->client_wrapper->get_authentication_url() );
@@ -57,6 +58,10 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	function handle_redirect_cookie()
 	{
+		if ( $GLOBALS['pagenow'] == 'wp-login.php' && isset( $_GET[ 'action' ] ) && $_GET[ 'action' ] === 'logout' ) {
+			return;
+		}
+
 		// record the URL of this page if set to redirect back to origin page
 		if ( $this->settings->redirect_user_back )
 		{

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -85,6 +85,13 @@ class OpenID_Connect_Generic_Settings_Page {
 				'type'        => 'text',
 				'section'     => 'client_settings',
 			),
+			'endpoint_end_session'    => array(
+				'title'       => __( 'End Session Endpoint URL' ),
+				'description' => __( 'Identify provider logout endpoint.' ),
+				'example'     => 'https://example.com/oauth2/logout',
+				'type'        => 'text',
+				'section'     => 'client_settings',
+			),
 			'identity_key'     => array(
 				'title'       => __( 'Identity Key' ),
 				'description' => __( 'Where in the user claim array to find the user\'s identification data. Possible standard values: preferred_username, name, or sub. If you\'re having trouble, use "sub".' ),


### PR DESCRIPTION
Hello,
This implements support for logging out from the IdP when logging out from WordPress (optional) if user specifies the end_session_endpoint in the plugin settings.