### PR TITLE
Set the Host header on http requests to openid-connect endpoint

### DIFF
--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -94,6 +94,11 @@ class OpenID_Connect_Generic_Client {
 	 * @return array|\WP_Error
 	 */
 	function request_authentication_token( $code ) {
+
+		// Add Host header - required for when the openid-connect endpoint is behind a reverse-proxy
+		$parsed_url = parse_url($this->endpoint_token);
+		$host = $parsed_url['host'];
+
 		$request = array(
 			'body' => array(
 				'code'          => $code,
@@ -102,7 +107,8 @@ class OpenID_Connect_Generic_Client {
 				'redirect_uri'  => $this->redirect_uri,
 				'grant_type'    => 'authorization_code',
 				'scope'         => $this->scope,
-			)
+			),
+			'headers' => array( 'Host' => $host )
 		);
 
 		// allow modifications to the request
@@ -156,6 +162,11 @@ class OpenID_Connect_Generic_Client {
 
 		$request['headers']['Authorization'] = 'Bearer '.$access_token;
 
+		// Add Host header - required for when the openid-connect endpoint is behind a reverse-proxy
+		$parsed_url = parse_url($this->endpoint_userinfo);
+		$host = $parsed_url['host'];
+		$request['headers']['Host'] = $host;
+
 		// attempt the request including the access token in the query string for backwards compatibility
 		$response = wp_remote_get( $this->endpoint_userinfo . '?access_token=' . $access_token, $request );
 
@@ -207,7 +218,6 @@ class OpenID_Connect_Generic_Client {
 		if ( isset( $states[ $state ] ) ) {
 			// state is valid, remove it
 			unset( $states[ $state ] );
-
 			$valid = TRUE;
 		}
 


### PR DESCRIPTION
Hi - I had to make a couple of tweaks to this file to make the plugin work in my environment as my openid-connect broker sits behind a reverse proxy, and it was not able to route the http requests properly unless the Host header was set. I hope this may be useful to others that have a similar setup.