### PR TITLE
Calls the wp_login action at the end of the login flow

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -441,7 +441,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		// you did great, have a cookie!
 		$this->issue_token_refresh_info_cookie( $user->ID, $token_response );
 		wp_set_auth_cookie( $user->ID, FALSE );
-        do_action( 'wp_login', $user->user_login, $user );
+		do_action( 'wp_login', $user->user_login, $user );
 	}
 
 	/**

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -441,6 +441,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		// you did great, have a cookie!
 		$this->issue_token_refresh_info_cookie( $user->ID, $token_response );
 		wp_set_auth_cookie( $user->ID, FALSE );
+        do_action( 'wp_login', $user->user_login, $user );
 	}
 
 	/**

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -113,7 +113,7 @@ class OpenID_Connect_Generic_Login_Form {
 		?>
 		<div id="login_error">
 			<strong><?php _e( 'ERROR'); ?>: </strong>
-			<?php print $error_message; ?>
+			<?php print esc_html($error_message); ?>
 		</div>
 		<?php
 		return ob_get_clean();


### PR DESCRIPTION
Many plugins will hook in to this action.

For example if a plugin was logging last logged in date it would use this function.