### PR TITLE
Authentication URL can be modified

### DIFF
--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -50,7 +50,7 @@ class OpenID_Connect_Generic_Client {
 			urlencode( $this->redirect_uri )
 		);
 
-		return $url;
+		return apply_filters( 'openid-connect-generic-auth-url', $url );
 	}
 
 	/**

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -19,6 +19,7 @@ Notes
   - openid-connect-generic-login-button-text  - modify the login button text 
   - openid-connect-generic-user-login-test    - (bool) should the user be logged in based on their claim
   - openid-connect-generic-user-creation-test - (bool) should the user be created based on their claim
+  - openid-connect-generic-auth-url           - modify the authentication url
 
   Actions
   - openid-connect-generic-user-create - 2 args: fires when a new user is created by this plugin


### PR DESCRIPTION
Some OpenID Connect providers offer additional functionality by adding query params to the authentication URL

For example with Azure Active Directory if you pass in `&domain_hint=REALM` you can customise the way the login screen looks with your corporate logo etc

Source: https://blogs.technet.microsoft.com/enterprisemobility/2015/02/11/using-azure-ad-to-land-users-on-their-custom-login-page-from-within-your-app/