### PR TITLE
Issue #36: Allow absence of refresh_token

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -136,9 +136,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		}
 
 		if ( ! isset( $_COOKIE[ $this->cookie_token_refresh_key] ) ) {
-			wp_logout();
-			$this->error_redirect( new WP_Error( 'token-refresh-cookie-missing', __( 'Single sign-on cookie missing. Please login again.' ), $_COOKIE ) );
-			exit;
+                        return;
 		}
 
 		$user_id = wp_get_current_user()->ID;


### PR DESCRIPTION
(Editor removed trailing whitespace)

Allow a user to proceed without `refresh_token`. This is fine as long as the wordpress/plugin does not request any resource from the OpenID-Connect/OAuth Resource Server.