### PR TITLE
Terminate authentication_request_callback() after execution

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -409,6 +409,8 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		else {
 			wp_redirect( home_url() );
 		}
+		
+		exit;
 	}
 
 	/**


### PR DESCRIPTION
Terminate callback function after wp_redirect() (per instructions [here](https://developer.wordpress.org/reference/functions/wp_redirect/)).

Fixes #46.