### PR TITLE
Fix #54 by tracking the id_token in the session

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -232,7 +232,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			do_action( 'wp_login', $login_user->user_login, $login_user );
 		} else {
 			// Only update session if a changed value was returned
-			if ($ret !== null && $ret != $data ) {
+			if ($ret !== null && $ret !== $data ) {
 				$manager->update($token, $session);
 			}
 		}


### PR DESCRIPTION
This patch saves the current user's id token in an instance variable during the `wp_load` action so that it can be used later by the logout redirect URI hook.

In order to do that, it was necessary to:

* Add the `id_token` to the WP session
* Update the plugin's session data in-place (since refresh responses may not include an `id_token`)
* Refactor the session management to allow in-place updates, and fully encapsulate session access

The last change means that all the funky WP-specific logic for tokens and session managers and whatnot is all in one method, used by both `login_user()` and `ensure_tokens_still_fresh()`.

In addition, the redirect hook no longer needs to access the user metadata.  In fact, the `openid-connect-generic-last-token-response` user meta field is now write-only as far as the plugin is concerned: the plugin never reads this value back.

I don't see a reason to drop the value, though.  It *does* seem to me that it would be useful to provide some API (perhaps static?) to access the session token info, for purposes of checking access rights.  The last-token-response is only valid as of the last time the user logged in, so if the user's access rights have changed since the last token refresh, that information will not be up to date.  (Perhaps the plugin should update the claims metadata when a token refresh occurs?)  But that's probably a subject for another issue and PR...  :)