### PR TITLE
Prefixes for better autoloading

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -24,10 +24,10 @@ class OpenID_Connect_Generic_Client_Wrapper {
 	 * Inject necessary objects and services into the client
 	 * 
 	 * @param \OpenID_Connect_Generic_Client $client
-	 * @param \WP_Option_Settings $settings
-	 * @param \WP_Option_Logger $logger
+	 * @param \OpenID_Connect_Generic_Option_Settings $settings
+	 * @param \OpenID_Connect_Generic_Option_Logger $logger
 	 */
-	function __construct( OpenID_Connect_Generic_Client $client, WP_Option_Settings $settings, WP_Option_Logger $logger ){
+	function __construct( OpenID_Connect_Generic_Client $client, OpenID_Connect_Generic_Option_Settings $settings, OpenID_Connect_Generic_Option_Logger $logger ){
 		$this->client = $client;
 		$this->settings = $settings;
 		$this->logger = $logger;
@@ -37,12 +37,12 @@ class OpenID_Connect_Generic_Client_Wrapper {
 	 * Hook the client into WP
 	 *
 	 * @param \OpenID_Connect_Generic_Client $client
-	 * @param \WP_Option_Settings $settings
-	 * @param \WP_Option_Logger $logger
+	 * @param \OpenID_Connect_Generic_Option_Settings $settings
+	 * @param \OpenID_Connect_Generic_Option_Logger $logger
 	 *
 	 * @return \OpenID_Connect_Generic_Client_Wrapper
 	 */
-	static public function register( OpenID_Connect_Generic_Client $client, WP_Option_Settings $settings, WP_Option_Logger $logger ){
+	static public function register( OpenID_Connect_Generic_Client $client, OpenID_Connect_Generic_Option_Settings $settings, OpenID_Connect_Generic_Option_Logger $logger ){
 		$client_wrapper  = new self( $client, $settings, $logger );
 		
 		// integrated logout

--- a/includes/openid-connect-generic-option-logger.php
+++ b/includes/openid-connect-generic-option-logger.php
@@ -2,9 +2,7 @@
 /**
  * Simple class for logging messages to the options table
  */
-if ( !class_exists( 'WP_Option_Logger' ) ) :
-		
-class WP_Option_Logger {
+class OpenID_Connect_Generic_Option_Logger {
 	
 	// wp option name/key
 	private $option_name;
@@ -82,7 +80,7 @@ class WP_Option_Logger {
 	/**
 	 * Save an array of data to the logs
 	 * 
-	 * @param $data array
+	 * @param $data mixed
 	 * @return bool
 	 */
 	public function log( $data, $type = null ) {
@@ -117,11 +115,13 @@ class WP_Option_Logger {
 	public function get_option_name(){
 		return $this->option_name;
 	}
-	
+
 	/**
 	 * Create a message array containing the data and other information
-	 * 
-	 * @param $data (mixed)
+	 *
+	 * @param $data mixed
+	 * @param $type
+	 *
 	 * @return array
 	 */
 	private function make_message( $data, $type ){
@@ -244,5 +244,3 @@ class WP_Option_Logger {
 		return $output;
 	}
 }
-
-endif;

--- a/includes/openid-connect-generic-option-settings.php
+++ b/includes/openid-connect-generic-option-settings.php
@@ -1,8 +1,8 @@
 <?php
-
-if ( ! class_exists( 'WP_Option_Settings' ) ) :
- 
-class WP_Option_Settings {
+/**
+ * Class OpenId_Connect_Generic_Option_Settings
+ */
+class OpenID_Connect_Generic_Option_Settings {
 	
 	// wp option name/key
 	private $option_name;
@@ -58,5 +58,3 @@ class WP_Option_Settings {
 		update_option( $this->option_name, $this->values );
 	}
 }
-
-endif;

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * Class OpenID_Connect_Generic_Settings_Page.
+ * Admin settings page.
+ */
 class OpenID_Connect_Generic_Settings_Page {
 
 	// local copy of the settings provided by the base plugin
@@ -16,10 +20,10 @@ class OpenID_Connect_Generic_Settings_Page {
 	private $settings_field_group;
 
 	/**
-	 * @param \WP_Option_Settings $settings
-	 * @param \WP_Option_Logger $logger
+	 * @param OpenID_Connect_Generic_Option_Settings $settings
+	 * @param OpenID_Connect_Generic_Option_Logger $logger
 	 */
-	function __construct( WP_Option_Settings $settings, WP_Option_Logger $logger ) {
+	function __construct( OpenID_Connect_Generic_Option_Settings $settings, OpenID_Connect_Generic_Option_Logger $logger ) {
 		$this->settings             = $settings;
 		$this->logger               = $logger;
 		$this->settings_field_group = $this->settings->get_option_name() . '-group';
@@ -196,12 +200,12 @@ class OpenID_Connect_Generic_Settings_Page {
 	}
 
 	/**
-	 * @param \WP_Option_Settings $settings
-	 * @param \WP_Option_Logger $logger
+	 * @param \OpenID_Connect_Generic_Option_Settings $settings
+	 * @param \OpenID_Connect_Generic_Option_Logger $logger
 	 *
 	 * @return \OpenID_Connect_Generic_Settings_Page
 	 */
-	static public function register( WP_Option_Settings $settings, WP_Option_Logger $logger ){
+	static public function register( OpenID_Connect_Generic_Option_Settings $settings, OpenID_Connect_Generic_Option_Logger $logger ){
 		$settings_page = new self( $settings, $logger );
 
 		// add our options page the the admin menu

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -61,10 +61,10 @@ class OpenID_Connect_Generic {
 	/**
 	 * Setup the plugin
 	 *
-	 * @param \WP_Option_Settings $settings
-	 * @param \WP_Option_Logger $logger
+	 * @param OpenID_Connect_Generic_Option_Settings $settings
+	 * @param OpenID_Connect_Generic_Option_Logger $logger
 	 */
-	function __construct( WP_Option_Settings $settings, WP_Option_Logger $logger ){
+	function __construct( OpenID_Connect_Generic_Option_Settings $settings, OpenID_Connect_Generic_Option_Logger $logger ){
 		$this->settings = $settings;
 		$this->logger = $logger;
 	}
@@ -157,6 +157,12 @@ class OpenID_Connect_Generic {
 	 * @param $class
 	 */
 	static public function autoload( $class ) {
+		$prefix = 'OpenID_Connect_Generic_';
+
+		if ( stripos($class, $prefix) !== 0 ) {
+			return;
+		}
+
 		$filename = $class . '.php';
 
 		// internal files are all lowercase and use dashes in filenames
@@ -180,7 +186,7 @@ class OpenID_Connect_Generic {
 	static public function bootstrap(){
 		spl_autoload_register( array( 'OpenID_Connect_Generic', 'autoload' ) );
 		
-		$settings = new WP_Option_Settings(
+		$settings = new OpenID_Connect_Generic_Option_Settings(
 			'openid_connect_generic_settings',
 			// default settings values
 			array(
@@ -214,7 +220,7 @@ class OpenID_Connect_Generic {
 			)
 		);
 		
-		$logger = new WP_Option_Logger( 'openid-connect-generic-logs', 'error', $settings->enable_logging, $settings->log_limit );
+		$logger = new OpenID_Connect_Generic_Option_Logger( 'openid-connect-generic-logs', 'error', $settings->enable_logging, $settings->log_limit );
 		
 		$plugin = new self( $settings, $logger );
 		


### PR DESCRIPTION
This patch is for #64 

Changed the generic classes used for options to have the `OpenID_Connect_Generic_` prefix so that the autoloader can easily compare the current class call to that prefix.
