### PR TITLE
Translit names' special characters

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -503,7 +503,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		}
 
 		// normalize the data a bit
-		$desired_username = strtolower( preg_replace( '/[^a-zA-Z\_0-9]/', '', $desired_username ) );
+		$desired_username = strtolower( preg_replace( '/[^a-zA-Z\_0-9]/', '', iconv( 'UTF-8', 'ASCII//TRANSLIT',  $desired_username ) ) );
 
 		// copy the username for incrementing
 		$username = $desired_username;


### PR DESCRIPTION
When nickname is generated from a full name, intent to translit them to ascii instead of stripping special characters.