### PR TITLE
hook: ability to filter claim and derived user data

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -700,18 +700,20 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			return new WP_Error( 'cannot-authorize', __( 'Can not authorize.' ), $create_user );
 		}
 
-		// create the new user
-		$uid = wp_insert_user(
-			array(
-				'user_login' => $username,
-				'user_pass' => wp_generate_password( 32, TRUE, TRUE ),
-				'user_email' => $email,
-				'display_name' => $displayname,
-				'nickname' => $nickname,
-				'first_name' => isset( $user_claim[ 'given_name' ] ) ? $user_claim[ 'given_name' ]: '',
-				'last_name' => isset( $user_claim[ 'family_name' ] ) ? $user_claim[ 'family_name' ]: '',
-			)
+		$user_claim = apply_filters( 'openid-connect-generic-alter-user-claim', $user_claim );
+		$user_data = array(
+			'user_login' => $username,
+			'user_pass' => wp_generate_password( 32, TRUE, TRUE ),
+			'user_email' => $email,
+			'display_name' => $displayname,
+			'nickname' => $nickname,
+			'first_name' => isset( $user_claim[ 'given_name' ] ) ? $user_claim[ 'given_name' ]: '',
+			'last_name' => isset( $user_claim[ 'family_name' ] ) ? $user_claim[ 'family_name' ]: '',
 		);
+		$user_data = apply_filters( 'openid-connect-generic-alter-user-data', $user_data, $user_claim );
+
+		// create the new user
+		$uid = wp_insert_user( $user_data );
 
 		// make sure we didn't fail in creating the user
 		if ( is_wp_error( $uid ) ) {


### PR DESCRIPTION
fixes #72 

Sample implementation:
```php
add_filter( 'openid-connect-generic-alter-user-data', function( array $user_data, array $user_claim ) {
    $username = explode( '@', $user_claim['email'] )[0];
    $user_data = array_merge( $user_data,
                              [ 'user_login' => $username,
                                'display_name' => $user_claim['name'],
                                'first_name' => $user_claim['given_name'],
                                'nickname' => $username ] );
    return $user_data;
}, 10, 2);
```