### PR TITLE
avoid messing-up with wp-cli

### DIFF
--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -73,6 +73,10 @@ class OpenID_Connect_Generic {
 	 * WP Hook 'init'
 	 */
 	function init(){
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return;
+		}
+
 		$redirect_uri = admin_url( 'admin-ajax.php?action=openid-connect-authorize' );
 
 		if ( $this->settings->alternate_redirect_uri ){


### PR DESCRIPTION
When using wp-cli (eg: rewrite/cache flush), `init()` will run `setcookie()` which would in turn triggers "headers already sent".
So just disable the plugin initialization when wp-cli is being used.