### PR TITLE
Allow identity providers which do not support the userinfo endpoint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/**/*
+composer.lock

--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -284,9 +284,9 @@ class OpenID_Connect_Generic_Client {
 	 * @return bool|\WP_Error
 	 */
 	function validate_token_response( $token_response ){
-		// we need to ensure 3 specific items exist with the token response in order
-		// to proceed with confidence:  id_token, access_token, and token_type == 'Bearer'
-		if ( ! isset( $token_response['id_token'] ) || ! isset( $token_response['access_token'] ) ||
+		// we need to ensure 2 specific items exist with the token response in order
+		// to proceed with confidence:  id_token and token_type == 'Bearer'
+		if ( ! isset( $token_response['id_token'] ) || 
 		     ! isset( $token_response['token_type'] ) || strcasecmp( $token_response['token_type'], 'Bearer' )
 		) {
 			return new WP_Error( 'invalid-token-response', 'Invalid token response', $token_response );


### PR DESCRIPTION
Thanks for sharing this plug-in! I had to make a few small changes to use it with Azure AD B2C as the identity provider. The userinfo endpoint isn't strictly required by the Open ID Connect spec, and Microsoft has chosen not to support it in the current release of Azure AD B2C. Instead, the user claims are returned in the id_token. I made a few small changes to make the userinfo endpoint optional.
