### PR TITLE
Allow override of the plugin by posting credentials to wp-login.php

### DIFF
--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -39,8 +39,9 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	function handle_redirect_login_type_auto()
 	{
-		if ( $GLOBALS['pagenow'] == 'wp-login.php' && $this->settings->login_type == 'auto'
-			&& ( ! isset( $_GET[ 'action' ] ) || $_GET[ 'action' ] !== 'logout' ) )
+        if ( $GLOBALS['pagenow'] == 'wp-login.php' && $this->settings->login_type == 'auto'
+            && ( ! isset( $_GET[ 'action' ] ) || $_GET[ 'action' ] !== 'logout' )
+            && ! isset( $_POST['wp-submit'] ) )
 		{
 			if (  ! isset( $_GET['login-error'] ) ) {
 				wp_redirect( $this->client_wrapper->get_authentication_url() );

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -39,9 +39,9 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	function handle_redirect_login_type_auto()
 	{
-        if ( $GLOBALS['pagenow'] == 'wp-login.php' && $this->settings->login_type == 'auto'
-            && ( ! isset( $_GET[ 'action' ] ) || $_GET[ 'action' ] !== 'logout' )
-            && ! isset( $_POST['wp-submit'] ) )
+		if ( $GLOBALS['pagenow'] == 'wp-login.php' && $this->settings->login_type == 'auto'
+			&& ( ! isset( $_GET[ 'action' ] ) || $_GET[ 'action' ] !== 'logout' )
+			&& ! isset( $_POST['wp-submit'] ) )
 		{
 			if (  ! isset( $_GET['login-error'] ) ) {
 				wp_redirect( $this->client_wrapper->get_authentication_url() );


### PR DESCRIPTION
In situations where developers want to allow both: local and federated login (SSO), we need to be able to allow passing (and thus processing) of login/password from a custom login page to wp-login.php. 