### PR TITLE
added force_redirect parameter and login action

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -378,7 +378,9 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		// login the found / created user
 		$this->login_user( $user, $token_response, $id_token_claim, $user_claim, $subject_identity  );
-		
+
+		do_action( 'openid-connect-generic-user-logged-in', $user );
+
 		// log our success
 		$this->logger->log( "Successful login for: {$user->user_login} ({$user->ID})", 'login-success' );
 

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -39,7 +39,8 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	function handle_redirect_login_type_auto()
 	{
-		if ( $GLOBALS['pagenow'] == 'wp-login.php' && $this->settings->login_type == 'auto'
+		if ( $GLOBALS['pagenow'] == 'wp-login.php'
+            && ( $this->settings->login_type == 'auto' || ! empty( $_GET['force_redirect'] ) )
 			&& ( ! isset( $_GET[ 'action' ] ) || $_GET[ 'action' ] !== 'logout' )
 			&& ! isset( $_POST['wp-submit'] ) )
 		{


### PR DESCRIPTION
With these changes I could log in an user using inappbrowser (ionic).
The following steps are needed: open inappbrowser -> go to wp login page (with force_redirect parameter) -> keycloak user-password form -> redirect back to wordpress (action puts jwt token to cookie) -> read token cookie and close inappbrowser.