### PR TITLE
avoid headers already sent error notice

### DIFF
--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -12,6 +12,9 @@ class OpenID_Connect_Generic_Login_Form {
 	function __construct( $settings, $client_wrapper ){
 		$this->settings = $settings;
 		$this->client_wrapper = $client_wrapper;
+
+		// maybe set redirect cookie on formular page
+		add_action('login_form_login', [$this, 'handle_redirect_cookie']);
 	}
 
 	/**
@@ -131,9 +134,6 @@ class OpenID_Connect_Generic_Login_Form {
 	function make_login_button() {
 		$text = apply_filters( 'openid-connect-generic-login-button-text', __( 'Login with OpenID Connect' ) );
 		$href = $this->client_wrapper->get_authentication_url();
-
-		// maybe set redirect cookie on formular page
-		$this->handle_redirect_cookie();
 
 		ob_start();
 		?>


### PR DESCRIPTION
This commit avoids error notice:
Warning: Cannot modify header information - headers already sent by (output started at XXX/wp-login.php:82) in XXX/wp-content/plugins/openid-connect-generic/includes/openid-connect-generic-login-form.php on line 86

zlib.output_compression must be 'off' such as other output buffers

fixes #140