### PR TITLE
 Add a setting checkbox defining the behavior of the client if a user…

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -356,12 +356,21 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		$subject_identity = $client->get_subject_identity( $id_token_claim );
 		$user = $this->get_user_by_identity( $subject_identity );
 
-		// if we didn't find an existing user, we'll need to create it
 		if ( ! $user ) {
-			$user = $this->create_new_user( $subject_identity, $user_claim );
-			if ( is_wp_error( $user ) ) {
-				$this->error_redirect( $user );
+
+
+			if($this->settings->create_if_does_not_exist)
+			{
+				$user = $this->create_new_user( $subject_identity, $user_claim );
+				if ( is_wp_error( $user ) ) {
+					$this->error_redirect( $user );
+					return;
+				}
+			}else{
+				$this->error_redirect(new WP_Error( 'identity-not-map-existing-user', __( "User identity is not link to an existing Wordpress user"), $user_claim ));
+
 				return;
+
 			}
 		}
 		else {

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -167,6 +167,13 @@ class OpenID_Connect_Generic_Settings_Page {
 				'type'        => 'checkbox',
 				'section'     => 'user_settings',
 			),
+			'create_if_does_not_exist'   => array(
+				'title'       => __( 'Create user if does not exist' ),
+				'description' => __( 'If the user identity is not link to an existing Wordpress user, it is created. If this setting is not enabled and if the user authenticates with an account which is not link to an existing Wordpress user then the authentication failed' ),
+				'type'        => 'checkbox',
+				'section'     => 'user_settings',
+				
+			),
 			'redirect_user_back'   => array(
 				'title'       => __( 'Redirect Back to Origin Page' ),
 				'description' => __( 'After a successful OpenID Connect authentication, this will redirect the user back to the page on which they clicked the OpenID Connect login button. This will cause the login process to proceed in a traditional WordPress fashion. For example, users logging in through the default wp-login.php page would end up on the WordPress Dashboard and users logging in through the WooCommerce "My Account" page would end up on their account page.' ),
@@ -274,6 +281,7 @@ class OpenID_Connect_Generic_Settings_Page {
 			// make sure each key exists in the settings array
 			if ( ! isset( $this->settings->{ $key } ) ) {
 				$this->settings->{ $key } = null;
+				
 			}
 
 			// determine appropriate output callback
@@ -401,7 +409,8 @@ class OpenID_Connect_Generic_Settings_Page {
 		<input type="checkbox"
 		       id="<?php print esc_attr( $field['key'] ); ?>"
 		       name="<?php print esc_attr( $field['name'] ); ?>"
-		       value="1"
+			   value="1",
+			   
 			<?php checked( $this->settings->{ $field['key'] }, 1 ); ?>>
 		<?php
 		$this->do_field_description( $field );

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -231,6 +231,7 @@ class OpenID_Connect_Generic {
 				'enforce_privacy' => 0,
 				'alternate_redirect_uri' => 0,
 				'link_existing_users' => 0,
+				'create_if_does_not_exist'=>1,
 				'redirect_user_back' => 0,
 				'redirect_on_logout' => 1,
 				'enable_logging'  => 0,


### PR DESCRIPTION
This pull request add a setting named "Create user if does not exist" . This checkbox add the following behavior when a user authenticates with an identity whic is not link to an existing WP user : 

- If tick, the user is created with the identity and then logged-in ( default behavior of the plugin)
- If not tick, an error indicating the user is not map to an existing WP user 

By default the checkbox is tick. 