### PR TITLE
Increment username just when link_existing_users is off

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -528,13 +528,15 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		// copy the username for incrementing
 		$username = $desired_username;
 
-		// original user gets "name"
-		// second user gets "name2"
-		// etc
-		$count = 1;
-		while ( username_exists( $username ) ) {
-			$count ++;
-			$username = $desired_username . $count;
+		if (!$this->settings->link_existing_users) {
+			// original user gets "name"
+			// second user gets "name2"
+			// etc
+			$count = 1;
+			while ( username_exists( $username ) ) {
+				$count ++;
+				$username = $desired_username . $count;
+			}
 		}
 
 		return $username;

--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -240,8 +240,7 @@ class OpenID_Connect_Generic_Client {
 	function new_state() {
 		// new state w/ timestamp
 		$state = md5( mt_rand() . microtime( true ) );
-		$expire = time() + $this->state_time_limit;
-		set_transient( 'openid-connect-generic-state--' . $state, $state, $expire );
+		set_transient( 'openid-connect-generic-state--' . $state, $state, $this->state_time_limit );
 
 		return $state;
 	}

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -180,11 +180,12 @@ class OpenID_Connect_Generic {
 	 */
 	function cron_states_garbage_collection() {
 		global $wpdb;
-		$states = $wpdb->get_col( "SELECT `option_name` FROM {$wpdb->options} WHERE `option_name` LIKE 'openid-connect-generic-state--%'" );
+		$states = $wpdb->get_col( "SELECT `option_name` FROM {$wpdb->options} WHERE `option_name` LIKE '_transient_openid-connect-generic-state--%'" );
 
 		if ( !empty( $states ) ) {
 			foreach ( $states as $state ) {
-				get_transient( $state );
+				$transient = str_replace("_transient_", "", $state);
+				get_transient( $transient );
 			}
 		}
 	}


### PR DESCRIPTION
Especially useful when you import users beforehand without user claims (e.g: _openid-connect-generic-subject-identity_) so that when they log in we don't create a duplicate WP user.