### PR TITLE
Increment username just when link_existing_users is off

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -534,13 +534,15 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		// copy the username for incrementing
 		$username = $desired_username;
 
-		// original user gets "name"
-		// second user gets "name2"
-		// etc
-		$count = 1;
-		while ( username_exists( $username ) ) {
+		if (!$this->settings->link_existing_users) {
+		  // original user gets "name"
+		  // second user gets "name2"
+		  // etc
+		  $count = 1;
+		  while ( username_exists( $username ) ) {
 			$count ++;
 			$username = $desired_username . $count;
+		  }
 		}
 
 		return $username;


### PR DESCRIPTION
Especially useful when you import users beforehand without user claims (e.g: _openid-connect-generic-subject-identity_) so that when they log in we don't create a duplicate WP user.