### PR TITLE
Delete expired transients

### DIFF
--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -248,8 +248,7 @@ class OpenID_Connect_Generic_Client {
 	function new_state() {
 		// new state w/ timestamp
 		$state = md5( mt_rand() . microtime( true ) );
-		$expire = time() + $this->state_time_limit;
-		set_transient( 'openid-connect-generic-state--' . $state, $state, $expire );
+		set_transient( 'openid-connect-generic-state--' . $state, $state, $this->state_time_limit );
 
 		return $state;
 	}

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -183,11 +183,12 @@ class OpenID_Connect_Generic {
 	 */
 	function cron_states_garbage_collection() {
 		global $wpdb;
-		$states = $wpdb->get_col( "SELECT `option_name` FROM {$wpdb->options} WHERE `option_name` LIKE 'openid-connect-generic-state--%'" );
+		$states = $wpdb->get_col( "SELECT `option_name` FROM {$wpdb->options} WHERE `option_name` LIKE '_transient_openid-connect-generic-state--%'" );
 
 		if ( !empty( $states ) ) {
 			foreach ( $states as $state ) {
-				get_transient( $state );
+			    $transient = str_replace("_transient_", "", $state);
+                get_transient( $transient );
 			}
 		}
 	}


### PR DESCRIPTION
- $expiration should be seconds not unix time while time() is added to the value you send ([link](https://developer.wordpress.org/reference/functions/set_transient/#parameters))

- "_transient _" or "_transient_timeout _" will be added to the name of your transient, so trying to search for a transient called "_transient__transient_openid-connect-generic-state--%" will, of course, return nothing ([link](https://developer.wordpress.org/reference/functions/get_transient/#more-information))

- So, because Wordpress adds a prefix to transients, I changed also what it searches for in the **delete_openid_transients** function