### PR TITLE
Release 3.7.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     name: New tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
 
         # - name: Validate composer.json and composer.lock
         #   run: composer validate

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,32 @@
-
 # OpenId Connect Generic Changelog
+
+3.7.0
+
+* Feature: @timnolte - Ability to enable/disable token refresh. Useful for IDPs that don't support token refresh.
+* Feature: @timnolte - Support custom redirect URL(`redirect_to`) with the authentication URL & login button shortcodes.
+  - Supports additional attribute overrides including login `button_text`, `endpoint_login`, `scope`, `redirect_uri`.
+
+3.6.0
+
+* Improvement: @RobjS - Improved error messages during login state failure.
+* Improvement: @RobjS - New developer filter for login form button URL.
+* Fix: @cs1m0n - Only increment username during new user creation if the "Link existing user" setting is enabled.
+* Fix: @xRy-42 - Allow periods and spaces in usernames to match what WordPress core allows.
+* Feature: @benochen - New setting named "Create user if does not exist" determines whether new users are created during login attempts.
+* Improvement: @flat235 - Username transliteration and normalization.
+
+3.5.1
+
+* Fix: @daggerhart - New approach to state management using transients.
+
+3.5.0
+
+* Readme fix: @thijskh - Fix syntax error in example openid-connect-generic-login-button-text
+* Feature: @slavicd - Allow override of the plugin by posting credentials to wp-login.php
+* Feature: @gassan - New action on use login
+* Fix: @daggerhart - Avoid double question marks in auth url query string
+* Fix: @drzraf - wp-cli bootstrap must not inhibit custom rewrite rules
+* Syntax change: @mullikine - Change PHP keywords to comply with PSR2
 
 **3.4.1**
 

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,11 @@
       "name": "Jonathan Daggerhart",
       "email": "jonathan@daggerhart.com",
       "homepage": "https://github.com/daggerhart"
+    },
+    {
+      "name": "Tim Nolte",
+      "email": "tim.nolte@ndigitals.com",
+      "homepage": "https://github.com/timnolte"
     }
   ],
   "keywords": [
@@ -19,7 +24,7 @@
     "issues": "https://github.com/daggerhart/openid-connect-generic/issues"
   },
   "require": {
-    "php": ">=5.3.3",
+    "php": ">=5.6.0",
     "composer/installers": "~1.0"
   }
 }

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -95,11 +95,22 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 	/**
 	 * Get the authentication url from the client
+	 * 
+	 * @param array $atts The optional attributes array when called via a shortcode.
 	 *
 	 * @return string
 	 */
-	function get_authentication_url(){
-		return $this->client->make_authentication_url();
+	function get_authentication_url( $atts = array() ){
+
+		if ( ! empty( $atts['redirect_to'] ) ) {
+			// Set the request query parameter used to set the cookie redirect.
+			$_REQUEST['redirect_to'] = $atts['redirect_to'];
+			$login_form = new OpenID_Connect_Generic_Login_Form( $this->settings, $this );
+			$login_form->handle_redirect_cookie();
+		}
+    
+		return $this->client->make_authentication_url( $atts );
+
 	}
 
 	/**

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -457,6 +457,9 @@ class OpenID_Connect_Generic_Client_Wrapper {
 	 * @param $token_response
 	 */
 	function save_refresh_token( $manager, $token, $token_response ) {
+		if ( ! $this->settings->token_refresh_enable ) {
+			return;
+		}
 		$session = $manager->get($token);
 		$now = current_time( 'timestamp' , true );
 		$session[$this->cookie_token_refresh_key] = array(

--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -45,20 +45,28 @@ class OpenID_Connect_Generic_Client {
 	/**
 	 * Create a single use authentication url
 	 *
+	 * @param array $atts An optional array of override/feature attributes.
+	 *
 	 * @return string
 	 */
-	function make_authentication_url() {
+	function make_authentication_url( $atts = array() ) {
+
+		$endpoint_login = ( ! empty( $atts['endpoint_login'] ) ) ? $atts['endpoint_login'] : $this->endpoint_login;
+		$scope = ( ! empty( $atts['scope'] ) ) ? $atts['scope'] : $this->scope;
+		$client_id = ( ! empty( $atts['client_id'] ) ) ? $atts['client_id'] : $this->client_id;
+		$redirect_uri = ( ! empty( $atts['redirect_uri'] ) ) ? $atts['redirect_uri'] : $this->redirect_uri;
+    
 		$separator = '?';
 		if ( stripos( $this->endpoint_login, '?' ) !== FALSE ) {
 			$separator = '&';
 		}
 		$url = sprintf( '%1$s%2$sresponse_type=code&scope=%3$s&client_id=%4$s&state=%5$s&redirect_uri=%6$s',
-			$this->endpoint_login,
+			$endpoint_login,
 			$separator,
-			rawurlencode( $this->scope ),
-			rawurlencode( $this->client_id ),
+			rawurlencode( $scope ),
+			rawurlencode( $client_id ),
 			$this->new_state(),
-			rawurlencode( $this->redirect_uri )
+			rawurlencode( $redirect_uri )
 		);
 
 		$this->logger->log( apply_filters( 'openid-connect-generic-auth-url', $url ), 'make_authentication_url' );

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -128,12 +128,20 @@ class OpenID_Connect_Generic_Login_Form {
 
 	/**
 	 * Create a login button (link)
+	 * 
+	 * @param array $atts Array of optional attributes to override login buton 
+	 * functionality when used by shortcode.
 	 *
 	 * @return string
 	 */
-	function make_login_button() {
-		$text = apply_filters( 'openid-connect-generic-login-button-text', __( 'Login with OpenID Connect' ) );
-		$href = apply_filters( 'openid-connect-generic-login-button-url', $this->client_wrapper->get_authentication_url() );
+	function make_login_button( $atts = array() ) {
+		$button_text = __( 'Login with OpenID Connect' );
+		if ( ! empty( $atts['button_text'] ) ) {
+			$button_text = $atts['button_text'];
+		}
+    
+		$text = apply_filters( 'openid-connect-generic-login-button-text', $button_text );
+		$href = $this->client_wrapper->get_authentication_url( $atts );
 
 		ob_start();
 		?>

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -161,6 +161,12 @@ class OpenID_Connect_Generic_Settings_Page {
 				'type'        => 'number',
 				'section'     => 'client_settings',
 			),
+			'token_refresh_enable'   => array(
+				'title'       => __( 'Enable Refresh Token' ),
+				'description' => __( 'If checked, support refresh tokens used to obtain access tokens from supported IDPs.' ),
+				'type'        => 'checkbox',
+				'section'     => 'client_settings',
+			),
 			'link_existing_users'   => array(
 				'title'       => __( 'Link Existing Users' ),
 				'description' => __( 'If a WordPress account already exists with the same identity as a newly-authenticated user over OpenID Connect, login as that user instead of generating an error.' ),

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -279,6 +279,7 @@ class OpenID_Connect_Generic {
 				// plugin settings
 				'enforce_privacy' => 0,
 				'alternate_redirect_uri' => 0,
+				'token_refresh_enable' => 1,
 				'link_existing_users' => 0,
 				'create_if_does_not_exist' => 1,
 				'redirect_user_back' => 0,

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -1,13 +1,29 @@
 <?php
-/*
-Plugin Name: OpenID Connect Generic
-Plugin URI: https://github.com/daggerhart/openid-connect-generic
-Description:  Connect to an OpenID Connect generic client using Authorization Code Flow
-Version: 3.6.0
-Author: daggerhart
-Author URI: http://www.daggerhart.com
-License: GPLv2 Copyright (c) 2015 daggerhart
-*/
+/**
+ * OpenID Connect Generic Client
+ *
+ * This plugin provides the ability to authenticate users with Identity 
+ * Providers using the OpenID Connect OAuth2 API with Authorization Code Flow.
+ *
+ * @category  Authentication
+ * @package   OpenID_Connect_Generic
+ * @author    Jonathan Daggerhart <jonathan@daggerhart.com>
+ * @author    Tim Nolte <tim.nolte@ndigitals.com>
+ * @copyright 2015-2020 daggerhart
+ * @license   http://www.gnu.org/licenses/gpl-2.0.txt GPL-2.0+
+ * @link      https://github.com/daggerhart
+ *
+ * @wordpress-plugin
+ * Plugin Name:       OpenID Connect Generic
+ * Plugin URI:        https://github.com/daggerhart/openid-connect-generic
+ * Description:       Connect to an OpenID Connect generic client using Authorization Code Flow.
+ * Version:           3.6.0
+ * Author:            daggerhart
+ * Author URI:        http://www.daggerhart.com
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ * GitHub Plugin URI: https://github.com/daggerhart/openid-connect-generic
+ */
 
 /*
 Notes
@@ -50,7 +66,7 @@ Notes
 
 class OpenID_Connect_Generic {
 	// plugin version
-	const VERSION = '3.6.0';
+	const VERSION = '3.7.0';
 
 	// plugin settings
 	private $settings;

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,11 @@
 === OpenID Connect Generic Client ===
-Contributors: daggerhart
+Contributors: daggerhart, tnolte
 Donate link: http://www.daggerhart.com/
 Tags: security, login, oauth2, openidconnect, apps, authentication, autologin, sso 
-Requires at least: 4
-Tested up to: 5.2.2
+Requires at least: 4.9
+Tested up to: 5.4.2
 Stable tag: trunk
+Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -49,6 +50,12 @@ On the settings page for this plugin (Dashboard > Settings > OpenID Connect Gene
 
 
 == Changelog ==
+
+= 3.7.0 =
+
+* Feature: @timnolte - Ability to enable/disable token refresh. Useful for IDPs that don't support token refresh.
+* Feature: @timnolte - Support custom redirect URL(`redirect_to`) with the authentication URL & login button shortcodes.
+  - Supports additional attribute overrides including login `button_text`, `endpoint_login`, `scope`, `redirect_uri`.
 
 = 3.6.0 =
 


### PR DESCRIPTION
- Feature: @timnolte - Ability to enable/disable token refresh. Useful for IDPs that don't support token refresh.
- Feature: @timnolte - Support custom redirect URL(redirect_to) with the authentication URL & login button shortcodes.
  - Supports additional attribute overrides including login button_text, endpoint_login, scope, redirect_uri.