### PR TITLE
Gitattributes for export exclusions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# Set default behavior to automatically normalize line endings.
+* text=auto
+
+# Force batch scripts to always use CRLF line endings so that if a repo is accessed
+# in Windows via a file share from Linux, the scripts will work.
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf
+
+# Force bash scripts to always use LF line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work.
+*.sh text eol=lf
+
+# Ignored directories during export.
+/.wordpress-org export-ignore
+/.github export-ignore
+/scripts export-ignore
+/tests export-ignore
+/tools export-ignore
+
+# Ignored files during export.
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/.wp-env.json export-ignore
+/composer.json export-ignore
+/composer.lock export-ignore
+/Gruntfile.js export-ignore
+/docker-compose.override.yml export-ignore
+/grumphp.yml.dist export-ignore
+/phpcs.xml.dist export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit.xml.dist export-ignore
+/package.json export-ignore
+/package-lock.json export-ignore


### PR DESCRIPTION
Read a few articles and reviewed some other repos to get a sense of gitattributes in general. This PR does 2 things w/ gitattributes:

1. Standardizes line endings on files (https://rehansaeed.com/gitattributes-best-practices/)
2. Ignores files and folders used for development during export

This can be tested by downloading the zip file for this branch from github -- https://github.com/daggerhart/openid-connect-generic/tree/feature/deployment-ignore-files -- Using that approach, it appears to be working correctly. 

I'm not completely sure if we need to update the readme to suggestion using `--prefer-dist` with composer. This answer seems to imply that it isn't necessary, it says that --prefer-dist is the default for packages that have stable releases (https://github.com/composer/composer/issues/4867#issuecomment-179157115)