### PR TITLE
Add shortcode only login option to settings

### DIFF
--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -111,7 +111,9 @@ class OpenID_Connect_Generic_Login_Form {
 		}
 
 		// Login button is appended to existing messages in case of error.
-		$message .= $this->make_login_button();
+		if ( 'shortcode' !== $this->settings->login_type ) {
+			$message .= $this->make_login_button();
+		}
 
 		return $message;
 	}

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -213,8 +213,9 @@ class OpenID_Connect_Generic_Settings_Page {
 				'description' => __( 'Select how the client (login form) should provide login options.', 'daggerhart-openid-connect-generic' ),
 				'type'        => 'select',
 				'options'     => array(
-					'button' => __( 'OpenID Connect button on login form', 'daggerhart-openid-connect-generic' ),
-					'auto'   => __( 'Auto Login - SSO', 'daggerhart-openid-connect-generic' ),
+					'button'    => __( 'OpenID Connect button on login form', 'daggerhart-openid-connect-generic' ),
+					'auto'      => __( 'Auto Login - SSO', 'daggerhart-openid-connect-generic' ),
+					'shortcode' => __( 'Shortcode Only', 'daggerhart-openid-connect-generic' ),
 				),
 				'disabled'    => defined( 'OIDC_LOGIN_TYPE' ),
 				'section'     => 'client_settings',


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/develop/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This small PR simply adds a **Shortcode Only** option to the Login Type settings:

<img width="667" height="202" alt="SCR-20260208-iuwv" src="https://github.com/user-attachments/assets/53a3233e-2468-4070-ae6d-2ba13d0233dc" />

The use-case for this option is a site that has (possibly many) public users who are not part of an organization's OIDC provider as well as staff who are. Using the **Shortcode Only** option allows us to provide a custom login page for staff which makes use of the login button provided by the plugin's shortcode while leaving the standard public login page with no changes and no reference to the openID login option.

We are currently running with this option in a large, public e-commerce site which processes hundreds of logins for both customers and staff daily and it's working perfectly with no issues.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Add "Shortcode Only" option as a new Login Type
