### PR TITLE
629: Fix to better match issuer in jwt validator

### DIFF
--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -620,9 +620,6 @@ class OpenID_Connect_Generic_Client {
 			}
 		}
 
-		// Add trailing slash (common for issuers).
-		$issuer .= '/';
-
 		return $issuer;
 	}
 
@@ -683,7 +680,7 @@ class OpenID_Connect_Generic_Client {
 			// Extract expected issuer from endpoint_login (base URL).
 			$expected_issuer = $this->get_issuer_from_endpoint( $this->endpoint_login );
 
-			if ( $id_token_claim['iss'] !== $expected_issuer ) {
+			if ( rtrim( $id_token_claim['iss'], '/' ) !== rtrim( $expected_issuer, '/' ) ) {
 				return new WP_Error(
 					'invalid-iss',
 					sprintf(

--- a/includes/openid-connect-generic-jwt-validator.php
+++ b/includes/openid-connect-generic-jwt-validator.php
@@ -227,7 +227,7 @@ class OpenID_Connect_Generic_JWT_Validator {
 				);
 			}
 
-			if ( $decoded_jwt->iss !== $this->issuer ) {
+			if ( rtrim( $decoded_jwt->iss, '/' ) !== rtrim( $this->issuer, '/' ) ) {
 				return new WP_Error(
 					'invalid-iss',
 					__( 'Token issuer does not match expected issuer.', 'daggerhart-openid-connect-generic' )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/develop/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #629.



### Changelog entry

> Fix bug created in 3.11.0 release where comparison of issuer is inconsistent.