### PR TITLE
Add missing configuration environment variables to HOWTO

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -82,6 +82,9 @@ On the settings page for this plugin (Dashboard > Settings > OpenID Connect Gene
 - Userinfo Endpoint URL: `OIDC_ENDPOINT_USERINFO_URL`
 - Token Validation Endpoint URL: `OIDC_ENDPOINT_TOKEN_URL`
 - End Session Endpoint URL: `OIDC_ENDPOINT_LOGOUT_URL`
+- JWKS URI: `OIDC_ENDPOINT_JWKS_URL`
+- Issuer: `OIDC_ISSUER`
+- ACR Values: `OIDC_ACR_VALUES`
 - OpenID scope: `OIDC_CLIENT_SCOPE` (space separated)
 - OpenID login type: `OIDC_LOGIN_TYPE` ('button' or 'auto')
 - Enforce privacy: `OIDC_ENFORCE_PRIVACY` (boolean)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/develop/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Some environment variables are missing in the HOWTO file. Configuring variables other than through the admin UI requires reading (and understanding) the `openid-connect-generic.php` file.
The missing variables are:
- JWKS URI
- issuer
- ACR values

This PR adds them.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Howto improvement: @Pierre-Lannoy - Adds JWKS URI, issuer and ACR environment variables definition.
