### PR TITLE
Use public function get_option_name instead of static value

### DIFF
--- a/includes/openid-connect-generic-option-logger.php
+++ b/includes/openid-connect-generic-option-logger.php
@@ -103,7 +103,7 @@ class OpenID_Connect_Generic_Option_Logger {
 	 */
 	public function get_logs() {
 		if ( empty( $this->logs ) ) {
-			$this->logs = get_option( self::OPTION_NAME, array() );
+			$this->logs = get_option( $this->get_option_name(), array() );
 		}
 
 		// Call the upkeep_logs function to give the appearance that logs have been reduced to the $this->log_limit.
@@ -196,7 +196,7 @@ class OpenID_Connect_Generic_Option_Logger {
 	private function save_logs( $logs ) {
 		// Save the logs.
 		$this->logs = $logs;
-		return update_option( self::OPTION_NAME, $logs, false );
+		return update_option( $this->get_option_name(), $logs, false );
 	}
 
 	/**

--- a/includes/openid-connect-generic-option-settings.php
+++ b/includes/openid-connect-generic-option-settings.php
@@ -122,7 +122,7 @@ class OpenID_Connect_Generic_Option_Settings {
 		$this->default_settings = $default_settings;
 		$this->values = array();
 
-		$this->values = (array) get_option( self::OPTION_NAME, $this->default_settings );
+		$this->values = (array) get_option( $this->get_option_name(), $this->default_settings );
 
 		// For each defined environment variable/constant be sure the settings key is set.
 		foreach ( $this->environment_settings as $key => $constant ) {
@@ -215,6 +215,6 @@ class OpenID_Connect_Generic_Option_Settings {
 			}
 		}
 
-		update_option( self::OPTION_NAME, $this->values );
+		update_option( $this->get_option_name(), $this->values );
 	}
 }


### PR DESCRIPTION
As get_option_name is public any child classes may implement get_option_name however currently this will not do what is intended due to accessing the property directly in the parent functions.

### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/develop/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/oidc-wp/openid-connect-generic/issues/667  .

### How to test the changes in this Pull Request:

1. subclass the classes 
2. Implement a `get_option_name` function that returns a new string 
3. See that a new `OPTION_NAME` is stored / logged

The existing tests should provide necessary coverage here to avoid any regression. 

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix:
- Use `get_option_name` in class functions instead of `self::OPTION_NAME` to ensure the correct value is used if subclassed.