### PR TITLE
fix: use priority 11 for ensure_tokens_still_fresh init hook

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -100,6 +100,8 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		add_filter( 'openid-connect-generic-alter-request', array( $client_wrapper, 'alter_request' ), 10, 2 );
 
 		// Ensure tokens are refreshed before they expire.
+		// Priority 11 runs after the default priority-10 init callbacks, ensuring
+		// session and auth state are fully initialised before checking token freshness.
 		if ( $settings->token_refresh_enable ) {
 			add_action( 'init', array( $client_wrapper, 'ensure_tokens_still_fresh' ), 11 );
 		}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -101,7 +101,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		// Ensure tokens are refreshed before they expire.
 		if ( $settings->token_refresh_enable ) {
-			add_action( 'init', array( $client_wrapper, 'ensure_tokens_still_fresh' ) );
+			add_action( 'init', array( $client_wrapper, 'ensure_tokens_still_fresh' ), 11 );
 		}
 
 		if ( is_admin() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generic/blob/develop/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`ensure_tokens_still_fresh` was registered as an `init` hook at the default priority 10. The problem is that this registration happens *inside* the plugin's own `init` callback, which also runs at priority 10. WordPress doesn't add callbacks to a priority that's currently executing — they're silently dropped. So token refresh was never called, even when enabled.

Changing to priority 11 puts it in the next batch WordPress processes, after the priority-10 queue drains.

One argument added, no other changes.

Closes #675.

### How to test the changes in this Pull Request:

1. Enable **Token Refresh** in the plugin settings.
2. Set a short access token lifetime on your IDP (e.g. 60 seconds).
3. Log in via OIDC.
4. Wait for the access token to expire.
5. Enable logging and load any page — the log should show a `request_new_tokens` entry. Before this fix it would not appear.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — No new test added; the existing flow is integration-level and requires a live IDP.
* [ ] Have you successfully run tests with your changes locally? — Confirmed via code inspection and the diagnosis in #675; live IDP testing requires infrastructure I don't have set up.

### Changelog entry

> Fix token refresh never running when enabled — `ensure_tokens_still_fresh` hook moved to priority 11 so it isn't dropped while the priority-10 `init` queue is executing.

(full disclosure, I used AI help with the testing and tweaks - Christopher)
