### PR TITLE
Fix the PR unit testing workflow so it can pass

### DIFF
--- a/.github/workflows/pr-unit-testing.yml
+++ b/.github/workflows/pr-unit-testing.yml
@@ -30,6 +30,24 @@ jobs:
     - name: Start Docker Environment
       run: docker compose up -d
 
+    # `docker compose up -d` returns as soon as the containers are created, not
+    # when the database is able to answer. Without this the test suite races
+    # MariaDB's initialisation and fails with "Error establishing a database
+    # connection". Querying the test database as the test user also confirms
+    # that tests/db-wordpress_test.sql has been applied.
+    - name: Wait for Database
+      run: |
+        for i in $(seq 1 30); do
+          if docker compose exec -T db sh -c 'mariadb -uwordpress -pwordpress -e "SELECT 1" wordpress_test || mysql -uwordpress -pwordpress -e "SELECT 1" wordpress_test' >/dev/null 2>&1; then
+            echo "Database is ready."
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "Database did not become available within 60 seconds."
+        docker compose logs db
+        exit 1
+
     - name: Run PHPUnit Tests
       run: docker compose exec app /bin/bash -c 'composer install && composer phpunit'
 
@@ -37,8 +55,12 @@ jobs:
       if: success() || failure()
       run: docker compose down
 
+    # No ${{ }} around the expression: an `if` is already an expression context,
+    # and the interpolated form is substituted as a string, which is always
+    # truthy. That made this step run on workflow_dispatch too, where there is
+    # no pull request to comment on, failing the whole job after a green suite.
     - name: Generate Coverage Report
-      if: success() && ${{ github.event_name == 'pull_request' }}
+      if: success() && github.event_name == 'pull_request'
       # https://github.com/marketplace/actions/coverage-report-as-comment-clover
       uses: lucassabreu/comment-coverage-clover@main
       with:


### PR DESCRIPTION
## Problem

The `PR Unit Testing` workflow has been failing on every run for a long time, including on pull requests that touch no PHP at all (several npm-only Dependabot PRs). Two independent defects in the workflow cause this, both unrelated to the code under test.

### 1. The suite races the database

`docker compose up -d` returns once the containers are *created*, not once MariaDB is able to answer. The next step immediately runs `composer install && composer phpunit`, so the bootstrap can reach the database before it is ready and the run dies with:

```
<h1>Error establishing a database connection</h1>
```

This is a race, which is why it looks intermittent.

### 2. The coverage step runs outside pull requests

```yaml
if: success() && ${{ github.event_name == 'pull_request' }}
```

An `if` is already an expression context. With the `${{ }}` form the expression is interpolated into a *string* before evaluation, and a non-empty string is truthy, so the condition never actually excludes anything. On `workflow_dispatch` the step therefore runs and fails with:

```
this action requires a pull request context to be able to comment
```

That turns the job red **after** the suite has already passed, which makes the failure look like a test failure when it is not.

## Change

- A `Wait for Database` step that polls the test database *as the test user*. That also confirms `tests/db-wordpress_test.sql` has been applied, not merely that the server is up. It gives up after 60 seconds and dumps `docker compose logs db` so a real database problem is still diagnosable.
- The `if` condition without `${{ }}`, so the coverage step is properly skipped when there is no pull request context.

One file, 23 lines added. No change to the plugin, the test suite or the dev environment.

## Verification

Run on this branch with the fix: **`OK (67 tests, 138 assertions)`**, job green.
https://github.com/sgreinerCNS/openid-connect-generic/actions/runs/31425036892

For comparison, the same workflow dispatched on unmodified `develop` reaches `OK (67 tests, 138 assertions)` in step 5 but is still reported as failed, because of defect 2.

## Note on `unit-testing.yml`

The release workflow has a separate, larger problem: it runs on the runner without the Docker environment, so `ABSPATH` falls back to the container path `/app/wp/` from `tests/phpunit/wp-tests-config.php` and there is no database service at all. Every run of it fails in the bootstrap:

```
require_once(/app/wp/wp-includes/PHPMailer/PHPMailer.php): Failed to open stream
Error in bootstrap script
```

I have left it alone here to keep this change small. Happy to follow up if you would like it switched to the same Docker path this workflow uses.

## Heads-up

We are adopting this plugin and reviewed it closely in the process. We have further changes we would like to contribute, some of which are security relevant. Following `SECURITY.md`, we will raise those through the private channel first rather than in a public issue or pull request, and we will wait for your response before proposing anything publicly. This pull request is deliberately limited to the CI fix, which contains nothing sensitive — but it is also what would let those later changes be reviewed against green checks.
